### PR TITLE
Fix ShellCheck workflow action version resolution

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@v2
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           # SC2034: unused variables — common in sourced scripts, suppress
           # SC1091: not following sourced file — files may not exist in CI


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for ShellCheck. The change updates the version of the `ludeeus/action-shellcheck` action to use the full semantic version (`2.0.0`) instead of the shorthand (`v2`).

- Updated the ShellCheck GitHub Action in `.github/workflows/shellcheck.yml` from `ludeeus/action-shellcheck@v2` to `ludeeus/action-shellcheck@2.0.0` to specify the exact version.